### PR TITLE
Fix Index.html documentation to say ":transpose-data??" with two question marks instead of one.

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,10 +137,10 @@ pluginspage="http://www.adobe.com/svg/viewer/install/" />
                    :xmin -5 :xmax 5
                    :ymin -1.5 :ymax 1.5)
           (add-points [x y1]
-                      :transpose-data? true
+                      :transpose-data?? true
                       :size 1)
           (add-points [x y2]
-                      :transpose-data? true
+                      :transpose-data?? true
                       :size 1
                       :fill (rgb 255 0 0))))))
 </code></pre>
@@ -165,7 +165,7 @@ pluginspage="http://www.adobe.com/svg/viewer/install/" />
        (emit-svg
           (-> (xy-plot :width 500 :height 500
                        :label-points? true)
-              (add-points [x y] :transpose-data? true)))))
+              (add-points [x y] :transpose-data?? true)))))
 </code></pre>
 </div>
 


### PR DESCRIPTION
This patch corrects the name of ":transpose-data??" key in index.html documentation -- it should have two question marks, not one. The given demo code fails mysteriously when just one question mark is used (it only plots two of the points, not 25.)
